### PR TITLE
Remove `fcntl_fcntl_impl` keeping `fcntl_ioctl_impl`

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-07-29-19-28-34.gh-issue-95380.6haDR2.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-07-29-19-28-34.gh-issue-95380.6haDR2.rst
@@ -1,0 +1,1 @@
+Remove max path size limit of 1024 for :func:`fcntl.ioctl` function.

--- a/Modules/clinic/fcntlmodule.c.h
+++ b/Modules/clinic/fcntlmodule.c.h
@@ -79,8 +79,7 @@ PyDoc_STRVAR(fcntl_ioctl__doc__,
 "If the argument is an immutable buffer (most likely a string) then a copy\n"
 "of the buffer is passed to the operating system and the return value is a\n"
 "string of the same length containing whatever the operating system put in\n"
-"the buffer.  The length of the arg buffer in this case is not allowed to\n"
-"exceed 1024 bytes.\n"
+"the buffer.\n"
 "\n"
 "If the arg given is an integer or if none is specified, the result value is\n"
 "an integer corresponding to the return value of the ioctl call in the C\n"
@@ -243,4 +242,4 @@ skip_optional:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=b8cb14ab35de4c6a input=a9049054013a1b77]*/
+/*[clinic end generated code: output=fdcb77f29c5b8df1 input=a9049054013a1b77]*/

--- a/Modules/fcntlmodule.c
+++ b/Modules/fcntlmodule.c
@@ -54,7 +54,7 @@ fcntl_fcntl_impl(PyObject *module, int fd, int code, PyObject *arg)
     int ret;
     char *str;
     Py_ssize_t len;
-    //char buf[1024];
+    char buf[1024];
     int async_err = 0;
 
     if (PySys_Audit("fcntl.fcntl", "iiO", fd, code, arg ? arg : Py_None) < 0) {
@@ -65,23 +65,11 @@ fcntl_fcntl_impl(PyObject *module, int fd, int code, PyObject *arg)
         int parse_result;
 
         if (PyArg_Parse(arg, "s#", &str, &len)) {
-            /*if ((size_t)len > sizeof buf) {
+            if ((size_t)len > sizeof buf) {
                 PyErr_SetString(PyExc_ValueError,
                                 "fcntl string arg too long");
                 return NULL;
-            }*/
-            char* buf = malloc((size_t)len);
-            PyObject* buf_ret;
-            if(buf == NULL) {
-                PyErr_NoMemory();
-                return NULL;
             }
-            /*PyObject *o = PyBytes_FromStringAndSize(NULL, len);
-            if (o == NULL) {
-                return NULL;
-            }
-            char *buf = PyBytes_AS_STRING(o);*/
-
             memcpy(buf, str, len);
             do {
                 Py_BEGIN_ALLOW_THREADS

--- a/Modules/fcntlmodule.c
+++ b/Modules/fcntlmodule.c
@@ -161,7 +161,7 @@ code.
 static PyObject *
 fcntl_ioctl_impl(PyObject *module, int fd, unsigned int code,
                  PyObject *ob_arg, int mutate_arg)
-/*[clinic end generated code: output=7f7f5840c65991be input=967b4a4cbeceb0a8]*/
+/*[clinic end generated code: output=7f7f5840c65991be input=6b70e7e5a8df40fa]*/
 {
     /* We use the unsigned non-checked 'I' format for the 'code' parameter
        because the system expects it to be a 32bit bit field value

--- a/Modules/fcntlmodule.c
+++ b/Modules/fcntlmodule.c
@@ -77,13 +77,9 @@ fcntl_fcntl_impl(PyObject *module, int fd, int code, PyObject *arg)
                 Py_END_ALLOW_THREADS
             } while (ret == -1 && errno == EINTR && !(async_err = PyErr_CheckSignals()));
             if (ret < 0) {
-                free(buf);
                 return !async_err ? PyErr_SetFromErrno(PyExc_OSError) : NULL;
             }
-            //return PyBytes_FromStringAndSize(buf, len);
-            buf_ret = PyBytes_FromStringAndSize(buf, len);
-            free(buf);
-            return(buf_ret);
+            return PyBytes_FromStringAndSize(buf, len);
         }
 
         PyErr_Clear();


### PR DESCRIPTION
Функция fcntl_fcntl_impl уже покрыта https://github.com/python/cpython/pull/95429, поэтому стоит сосредоточиться на fcntl_ioctl_impl, убрав дублирование из https://github.com/python/cpython/pull/95439.

Заодно перегенерировал код, преобразующий питоновый вызов в сишный с попутными проверкой и преобразованием параметров.